### PR TITLE
Add line length variable and scale column widths proportionally

### DIFF
--- a/py2Tex.py
+++ b/py2Tex.py
@@ -12,10 +12,10 @@ TODO documentation
 __author__ = 'intentodemusico'
 
 
-from tensorflow.keras import Model
+import tensorflow as tf
 
 
-def m2tex(model: Model, modelName: str, line_length: int):
+def m2tex(model: tf.keras.Model, modelName: str, line_length: int):
     stringlist = []
     model.summary(line_length=line_length, print_fn=lambda x: stringlist.append(x))
     del stringlist[1:-4:2]

--- a/py2Tex.py
+++ b/py2Tex.py
@@ -12,14 +12,19 @@ TODO documentation
 __author__ = 'intentodemusico'
 
 
-def m2tex(model,modelName):
+from tensorflow.keras import Model
+
+
+def m2tex(model: Model, modelName: str, line_length: int):
     stringlist = []
-    model.summary(line_length=70, print_fn=lambda x: stringlist.append(x))
+    model.summary(line_length=line_length, print_fn=lambda x: stringlist.append(x))
     del stringlist[1:-4:2]
     del stringlist[-1]
     for ix in range(1,len(stringlist)-3):
         tmp = stringlist[ix]
-        stringlist[ix] = tmp[0:31]+"& "+tmp[31:59]+"& "+tmp[59:]+"\\\\ \hline"
+        first_vertical_border = int(31/70 * line_length)
+        second_vertical_border = int(59/70 * line_length)
+        stringlist[ix] = tmp[0:first_vertical_border]+"& "+tmp[first_vertical_border:second_vertical_border]+"& "+tmp[second_vertical_border:]+"\\\\ \hline"
     stringlist[0] = "Model: {} \\\\ \hline".format(modelName)
     stringlist[1] += " \hline"
     stringlist[-4] += " \hline"
@@ -28,7 +33,7 @@ def m2tex(model,modelName):
     stringlist[-1] += " \\\\ \hline"
     prefix = ["\\begin{table}[]", "\\begin{tabular}{lll}"]
     suffix = ["\end{tabular}", "\caption{{Model summary for {}.}}".format(modelName), "\label{tab:model-summary}" , "\end{table}"]
-    stringlist = prefix + stringlist + suffix 
+    stringlist = prefix + stringlist + suffix
     out_str = " \n".join(stringlist)
     out_str = out_str.replace("_", "\_")
     out_str = out_str.replace("#", "\#")

--- a/py2Tex.py
+++ b/py2Tex.py
@@ -20,10 +20,10 @@ def m2tex(model: Model, modelName: str, line_length: int):
     model.summary(line_length=line_length, print_fn=lambda x: stringlist.append(x))
     del stringlist[1:-4:2]
     del stringlist[-1]
-    for ix in range(1,len(stringlist)-3):
+    first_vertical_border = int(31 / 70 * line_length)
+    second_vertical_border = int(59 / 70 * line_length)
+    for ix in range(1, len(stringlist) - 3):
         tmp = stringlist[ix]
-        first_vertical_border = int(31/70 * line_length)
-        second_vertical_border = int(59/70 * line_length)
         stringlist[ix] = tmp[0:first_vertical_border]+"& "+tmp[first_vertical_border:second_vertical_border]+"& "+tmp[second_vertical_border:]+"\\\\ \hline"
     stringlist[0] = "Model: {} \\\\ \hline".format(modelName)
     stringlist[1] += " \hline"


### PR DESCRIPTION
Hi, 
I encountered error while increasing line width from 70 to 100. The output table was:
![Screenshot from 2023-05-28 15-53-46](https://github.com/intentodemusico/py2Tex/assets/29732555/ee29ba27-cba9-4041-a99a-33d5674df23c)

As you can see, parts of longer names were in second column and shapes in param column.
What I did was to scale column width according to chosen line width. With changes table looks like this:
![image](https://github.com/intentodemusico/py2Tex/assets/29732555/c05fef2f-b76a-4a19-a44e-139bf81abdb8)

Hope it helps :).

Best,
Marcin